### PR TITLE
Updated standard to version 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/christophwitzko/git-head",
   "devDependencies": {
     "semantic-release": "3.4.1",
-    "standard": "5.3.0",
+    "standard": "10.0.0",
     "tap-spec": "2.2.2",
     "tape": "3.5.0"
   },


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!